### PR TITLE
Test improvement

### DIFF
--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -3,6 +3,7 @@
 namespace MallardDuck\Whois\Test;
 
 use PHPUnit\Framework\TestCase;
+use League\Uri\Components\Exception;
 
 /**
 *  Corresponding Class to test the whois Client class
@@ -21,7 +22,7 @@ abstract class BaseTest extends TestCase
      */
     public function getUriException()
     {
-        return \League\Uri\Components\Exception::class;
+        return Exception::class;
     }
 
     /**

--- a/tests/DomainLocatorLookupsTest.php
+++ b/tests/DomainLocatorLookupsTest.php
@@ -27,8 +27,9 @@ class DomainLocatorLookupsTest extends TestCase
     {
         $var = new DomainLocator();
         $results = $var->findWhoisServer($domain)->getWhoisServer();
-        $this->assertTrue(is_string($results) && !empty($results));
-        $this->assertTrue($server === $results);
+        $this->assertIsString($results);
+        $this->assertNotEmpty($results);
+        $this->assertSame($server, $results);
         unset($var, $results);
     }
 
@@ -42,8 +43,9 @@ class DomainLocatorLookupsTest extends TestCase
     {
         $var = new DomainLocator();
         $results = $var->getWhoisServer($domain);
-        $this->assertTrue(is_string($results) && !empty($results));
-        $this->assertTrue($server === $results);
+        $this->assertIsString($results);
+        $this->assertNotEmpty($results);
+        $this->assertSame($server, $results);
         unset($var, $results);
     }
 

--- a/tests/DomainLocatorTest.php
+++ b/tests/DomainLocatorTest.php
@@ -3,6 +3,7 @@
 namespace MallardDuck\Whois\Test;
 
 use PHPUnit\Framework\TestCase;
+use Tightenco\Collect\Support\Collection;
 use MallardDuck\Whois\WhoisServerList\DomainLocator;
 
 /**
@@ -28,9 +29,9 @@ class DomainLocatorTest extends TestCase
         $reflection_property->setAccessible(true);
         // Using this value we'll do a few assertions.
         $whoisCollection = $reflection_property->getValue($var);
-        $this->assertTrue(is_object($var));
-        $this->assertTrue("Tightenco\\Collect\\Support\\Collection" === get_class($whoisCollection));
-        $this->assertTrue(1229 === $whoisCollection->count(), "The whois domain count is off.");
+        $this->assertIsObject($var);
+        $this->assertInstanceOf(Collection::class, $whoisCollection);
+        $this->assertSame(1229, $whoisCollection->count(), "The whois domain count is off.");
         unset($var);
     }
 
@@ -40,7 +41,7 @@ class DomainLocatorTest extends TestCase
     public function testIsThereAnySyntaxError()
     {
         $var = new DomainLocator();
-        $this->assertTrue(is_object($var));
+        $this->assertIsObject($var);
         unset($var);
     }
 
@@ -52,13 +53,17 @@ class DomainLocatorTest extends TestCase
         $var = new DomainLocator();
         $var->findWhoisServer("google.com");
         $match = $var->getLastMatch();
-        $this->assertTrue(is_string($match) && !empty($match) && strlen($match) >= 1);
+        $this->assertIsString($match);
+        $this->assertNotEmpty($match);
+        $this->assertGreaterThanOrEqual(1, strlen($match));
         unset($var, $match);
 
         $var = new DomainLocator();
         $var->findWhoisServer("danpock.xyz");
         $match = $var->getLastMatch();
-        $this->assertTrue(is_string($match) && !empty($match) && strlen($match) >= 1);
+        $this->assertIsString($match);
+        $this->assertNotEmpty($match);
+        $this->assertGreaterThanOrEqual(1, strlen($match));
         unset($var, $match);
     }
 }

--- a/tests/WhoisClientRawTest.php
+++ b/tests/WhoisClientRawTest.php
@@ -21,7 +21,7 @@ class WhoisClientRawTest extends BaseTest
     public function testIsThereAnySyntaxError()
     {
         $var = new Client();
-        $this->assertTrue(is_object($var));
+        $this->assertIsObject($var);
         unset($var);
     }
 
@@ -31,11 +31,12 @@ class WhoisClientRawTest extends BaseTest
     public function testBasicRequestConcepts()
     {
         $var = new Client();
-        $this->assertTrue(is_object($var));
+        $this->assertIsObject($var);
         $var->createConnection("whois.nic.me");
         $status = $var->makeRequest("danpock.me");
         $response = $var->getResponseAndClose();
-        $this->assertTrue(strstr($response, "\r\n", true) === "Domain Name: DANPOCK.ME");
+        $containedResponse = strstr($response, "\r\n", true);
+        $this->assertSame("Domain Name: DANPOCK.ME", $containedResponse);
 
         unset($response, $status, $var);
     }

--- a/tests/WhoisClientTest.php
+++ b/tests/WhoisClientTest.php
@@ -22,7 +22,7 @@ class WhoisClientTest extends BaseTest
     public function testIsThereAnySyntaxError()
     {
         $var = new Client();
-        $this->assertTrue(is_object($var));
+        $this->assertIsObject($var);
         unset($var);
     }
 
@@ -33,7 +33,7 @@ class WhoisClientTest extends BaseTest
     {
         $this->expectException(MissingArgException::class);
         $var = new Client();
-        $this->assertTrue(is_object($var));
+        $this->assertIsObject($var);
         $var->lookup();
         unset($var);
     }
@@ -45,9 +45,9 @@ class WhoisClientTest extends BaseTest
     {
         $var = new Client();
         $results = $var->lookup("google.com");
-        $this->assertTrue(!empty($results));
-        $this->assertTrue(is_string($results));
-        $this->assertTrue(1 <= count(explode("\r\n", $results)));
+        $this->assertNotEmpty($results);
+        $this->assertIsString($results);
+        $this->assertGreaterThanOrEqual(1, count(explode("\r\n", $results)));
         unset($var, $results);
     }
 
@@ -58,7 +58,8 @@ class WhoisClientTest extends BaseTest
     {
         $client = new Client();
         $rawResults = $client->makeSafeWhoisRequest("danpock.me", "whois.nic.me");
-        $this->assertTrue(strstr($rawResults, "\r\n", true) === "Domain Name: DANPOCK.ME");
+        $rawContainedResults = strstr($rawResults, "\r\n", true);
+        $this->assertSame("Domain Name: DANPOCK.ME", $rawContainedResults);
         unset($client, $rawResults);
     }
 
@@ -74,7 +75,7 @@ class WhoisClientTest extends BaseTest
         $this->assertTrue(method_exists($client, 'parseWhoisDomain'));
         $foo = self::getMethod($client, 'parseWhoisDomain');
         $wat = $foo->invokeArgs($client, [$domain]);
-        $this->assertTrue($parsed === $wat);
+        $this->assertSame($parsed, $wat);
         unset($client, $foo, $wat);
     }
 

--- a/tests/WhoisDomainTest.php
+++ b/tests/WhoisDomainTest.php
@@ -25,7 +25,7 @@ class WhoisDomainTest extends BaseTest
     /**
      * The PHPUnit Setup method to build our client.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->client = new Client();
     }
@@ -35,7 +35,7 @@ class WhoisDomainTest extends BaseTest
      */
     public function testIsThereAnySyntaxError()
     {
-        $this->assertTrue(is_object($this->client));
+        $this->assertIsObject($this->client);
     }
 
     /**
@@ -46,7 +46,7 @@ class WhoisDomainTest extends BaseTest
     public function testValidDomains($domain)
     {
         $response = $this->client->lookup($domain);
-        $this->assertTrue(1 <= strlen($response));
+        $this->assertGreaterThanOrEqual(1, strlen($response));
     }
 
     /**

--- a/tests/WhoisLocatorExceptionTest.php
+++ b/tests/WhoisLocatorExceptionTest.php
@@ -37,8 +37,9 @@ class WhoisLocatorExceptionTest extends TestCase
     {
         $var = new DomainLocator();
         $results = $var->findWhoisServer("com.com")->getWhoisServer();
-        $this->assertTrue(is_string($results) && !empty($results));
-        $this->assertTrue("whois.verisign-grs.com" === $results);
+        $this->assertIsString($results);
+        $this->assertNotEmpty($results);
+        $this->assertSame("whois.verisign-grs.com", $results);
 
         $this->expectException(MissingArgException::class);
 
@@ -69,8 +70,9 @@ class WhoisLocatorExceptionTest extends TestCase
     {
         $var = new DomainLocator();
         $results = $var->findWhoisServer("com.com")->getWhoisServer();
-        $this->assertTrue(is_string($results) && !empty($results));
-        $this->assertTrue("whois.verisign-grs.com" === $results);
+        $this->assertIsString($results);
+        $this->assertNotEmpty($results);
+        $this->assertSame("whois.verisign-grs.com", $results);
 
         if (version_compare(phpversion(), "7.0", ">=")) {
             $this->expectException(MissingArgException::class);
@@ -89,8 +91,9 @@ class WhoisLocatorExceptionTest extends TestCase
     {
         $var = new DomainLocator();
         $results = $var->getWhoisServer("bing.com");
-        $this->assertTrue(is_string($results) && !empty($results));
-        $this->assertTrue("whois.verisign-grs.com" === $results);
+        $this->assertIsString($results);
+        $this->assertNotEmpty($results);
+        $this->assertSame("whois.verisign-grs.com", $results);
         unset($var, $results);
 
         $this->expectException(MissingArgException::class);
@@ -108,8 +111,9 @@ class WhoisLocatorExceptionTest extends TestCase
         $var = new DomainLocator();
         $results = $var->getWhoisServer("bing.com");
         $orgResults = $results;
-        $this->assertTrue(is_string($results) && !empty($results));
-        $this->assertTrue("whois.verisign-grs.com" === $results);
+        $this->assertIsString($results);
+        $this->assertNotEmpty($results);
+        $this->assertSame("whois.verisign-grs.com", $results);
         unset($results);
 
         $results = $var->getWhoisServer();


### PR DESCRIPTION
# Changed log
- Using the `assertIsString` to expected type is `string`.
- Using the `assertIsObject` to expected type is `object`.
- Using the `assertNotEmpty` to expected type is set and not empty.
- According to the [PHPUnit fixtures reference](https://phpunit.de/manual/7.0/en/fixtures.html), the `setUp` method is `protected function setUp(): void`.